### PR TITLE
Add assertion for missing rule ID in get_rule_by_id

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -49,12 +49,17 @@ def test_rules_manager_ignores_rules():
 def test_rules_manager_get_rule_by_id():
     """Test retrieving a specific rule by ID"""
     rules_manager = RulesManager()
-    rule = rules_manager.get_rule_by_id('SEC01')
     
+    # Test existing rule
+    rule = rules_manager.get_rule_by_id('SEC01')
     assert rule is not None
     assert rule['id'] == 'SEC01'
     assert 'weight' in rule
     assert 'type' in rule
+    
+    # Test non-existing rule
+    non_existent_rule = rules_manager.get_rule_by_id('NONEXISTENT_999')
+    assert non_existent_rule is None
 
 
 def test_rules_manager_get_critical_rules():


### PR DESCRIPTION
### FabGPT — code quality

**File:** `tests/test_rules.py`

**Rationale:** The test `test_rules_manager_get_rule_by_id` asserts that `get_rule_by_id` returns a non-None value, but the underlying implementation is not tested for the case where the requested rule ID does not exist. This leaves a potential `None` return value unverified, which could cause `AttributeError` in downstream code relying on the returned object.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen/qwen3.5-9b` · task `332cfe672f2a1170` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"332cfe672f2a1170","source":"quality","model":"qwen/qwen3.5-9b","severity":"INFO","iterations":1,"inference_s":64.68,"prompt_sha":"bcfeb39e944df64b","triage":"INFO"} -->