### PR TITLE
chore: add MIT LICENSE and fix Project Structure entry

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fabrizio Salmi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ vibe-check/
 │   ├── test_violations.js   # JS violations for testing
 │   └── test_violations.md   # Documentation violations
 ├── vibeguard.py          # Main entry point (REFACTORED)
-├── vibeguard.py              # Legacy entry point (deprecated)
+├── vibeguard_legacy.py   # Legacy entry point (deprecated)
 ├── requirements.txt          # Python dependencies
 ├── action.yml                # GitHub Action definition
 ├── Dockerfile                # Container definition


### PR DESCRIPTION
## What
- **Add MIT `LICENSE`** — the README badge (`License: MIT`) and License section link to `[LICENSE](LICENSE)`, but no license file existed (broken link). Adds the standard MIT text (© Fabrizio Salmi).
- **Fix Project Structure tree** — the legacy entry was listed as `vibeguard.py` (a duplicate of the main entry); the actual file is `vibeguard_legacy.py`.

Paired with a settings change (enabling GitHub Discussions) so the README's Discussions support link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)